### PR TITLE
docs: Add Docker Hub badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# pyhf-validation-root-base
+# pyhf validation ROOT base Docker image
+
 ROOT 6 Docker image with Python 3
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/pyhf/pyhf-validation-root-base)](https://hub.docker.com/r/pyhf/pyhf-validation-root-base)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/pyhf/pyhf-validation-root-base/latest)](https://hub.docker.com/r/pyhf/pyhf-validation-root-base/tags?name=latest)


### PR DESCRIPTION
Add Docker Hub pull count and image size badges to the README

[![Docker Pulls](https://img.shields.io/docker/pulls/pyhf/pyhf-validation-root-base)](https://hub.docker.com/r/pyhf/pyhf-validation-root-base)
[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/pyhf/pyhf-validation-root-base/latest)](https://hub.docker.com/r/pyhf/pyhf-validation-root-base/tags?name=latest)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add Docker Hub pull count and image size badges 
```