### PR TITLE
feat: Add curl to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,13 @@ ENV PATH="/opt/condaenv/bin:$PATH"
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
+RUN apt-get -qq -y update && \
+    apt-get -qq -y --no-install-recommends install \
+      curl && \
+    apt-get -y autoclean && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt-get/lists/* && \
+
 WORKDIR /home/data
 ENV HOME /home
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get -qq -y update && \
       curl && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
-    rm -rf /var/lib/apt-get/lists/* && \
+    rm -rf /var/lib/apt-get/lists/*
 
 WORKDIR /home/data
 ENV HOME /home


### PR DESCRIPTION
`curl` is used routinely to stream information and data and so should be added to the base image. This will also save it needing to be installed with each run of the CI in [`pyhf/pyhf-validation`](https://github.com/pyhf/pyhf-validation).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add curl to the image given frequent use
```