### PR TITLE
fix: Use root-binaries conda-forge package as build base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           --tag pyhf/pyhf-validation-root-base:$GITHUB_SHA \
           --compress
         docker images
+    - name: Check PATH
+      run: |
+        docker run --rm pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "which python;python --version;which root;root-config --version"
     - name: Run tests
       run: |
         docker run --rm -v $PWD:$PWD -w $PWD pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "python tests/rf308_normintegration2d.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Check PATH
       run: |
         docker run --rm pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "which python;python --version;which root;root-config --version;hist2workspace --help"
+        docker run --rm pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "which curl;which tar"
     - name: Run tests
       run: |
         docker run --rm -v $PWD:$PWD -w $PWD pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "python tests/rf308_normintegration2d.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         docker images
     - name: Check PATH
       run: |
-        docker run --rm pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "which python;python --version;which root;root-config --version"
+        docker run --rm pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "which python;python --version;which root;root-config --version;hist2workspace --help"
     - name: Run tests
       run: |
         docker run --rm -v $PWD:$PWD -w $PWD pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "python tests/rf308_normintegration2d.py"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN conda config --add channels conda-forge && \
     conda config --set allow_softlinks false && \
     conda config --set always_copy true
 RUN conda create --yes --quiet -p /opt/condaenv \
-  "root_base=$ROOT_VERSION" \
+  "root=$ROOT_VERSION" \
   "python=$PYTHON_VERSION"
 # Forcibly remove some packages to make the final image smaller
 # c.f. https://github.com/conda-forge/root-feedstock/blob/master/recipe/meta.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN conda config --add channels conda-forge && \
     conda config --set allow_softlinks false && \
     conda config --set always_copy true
 RUN conda create --yes --quiet -p /opt/condaenv \
-  "root=$ROOT_VERSION" \
+  "root-binaries=$ROOT_VERSION" \
   "python=$PYTHON_VERSION"
 # Forcibly remove some packages to make the final image smaller
 # c.f. https://github.com/conda-forge/root-feedstock/blob/master/recipe/meta.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,13 @@ RUN conda create --yes --quiet -p /opt/condaenv \
 # c.f. https://github.com/conda-forge/root-feedstock/blob/master/recipe/meta.yaml
 RUN eval "$(python -m conda shell.bash hook)" && \
     conda activate /opt/condaenv && \
-    conda install -y \
-      libblas \
-      libcblas \
-      fftw \
-      zlib
+    conda remove --yes --force-remove \
+      pythia8 \
+      qt \
+      libllvm9 \
+      libclang \
+      pandoc \
+      xrootd
 RUN rm -rf /opt/condaenv/tutorials /opt/condaenv/ui5
 
 FROM base


### PR DESCRIPTION
- Resolves #4 
- Needed by [`pyhf/pyhf-validation` PR 9](https://github.com/pyhf/pyhf-validation/pull/9)

As (pointed out by @kratsg) [`root_base`](https://anaconda.org/conda-forge/root_base) doesn't doesn't copy any of the compiled C++ code over, a build that is based on `root_base` won't actually have a working `ROOT` installation (though `PyROOT` will work). As a result of this, base the build around the `conda-forge` package [`root-binaries`](https://anaconda.org/conda-forge/root-binaries) instead which does include a `ROOT` runtime.

The current `root_base` based image is `551.49 MB` compressed, and this `root-binaries` build is `568.43 MB` compressed, so I think the size increase isn't too bad.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Base build around conda-forge 'root-binaries' to get ROOT runtime
* Add checks to build CI for ROOT, hist2workspace, and common utilities
```