### PR TITLE
refactor: Use ATLAS Stats stats-base as base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ jobs:
       run: |
         docker build . \
           --file Dockerfile \
-          --build-arg BASE_IMAGE=python:3.7-slim \
-          --build-arg ROOT_VERSION=6.20.00 \
+          --build-arg BASE_IMAGE=atlasamglab/stats-base:root6.20.00-python3.7 \
           --tag pyhf/pyhf-validation-root-base:$GITHUB_SHA \
           --compress
         docker images

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=atlasamglab/stats-base:root6.20.00-python3.7
 FROM ${BASE_IMAGE} as base
 
 RUN apt-get -qq -y update && \
-    apt-get -qq -y install git && \
+    apt-get -qq -y install --no-install-recommends git && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*
@@ -10,4 +10,5 @@ RUN apt-get -qq -y update && \
 WORKDIR /home/data
 ENV HOME /home
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "-l", "-c"]
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,71 +1,11 @@
-ARG BASE_IMAGE=python:3.7-slim
+ARG BASE_IMAGE=atlasamglab/stats-base:root6.20.00-python3.7
 FROM ${BASE_IMAGE} as base
 
-SHELL [ "/bin/bash", "-c" ]
-
-FROM base as builder
-
-ARG ROOT_VERSION=6.20.00
-
-# As this is builder can split up RUNs to make debugging easier
-COPY packages.txt packages.txt
 RUN apt-get -qq -y update && \
-    apt-get -qq -y install $(cat packages.txt) && \
+    apt-get -qq -y install git && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*
-# c.f. https://root.cern.ch/building-root#options
-RUN mkdir code && \
-    cd code && \
-    wget https://root.cern/download/root_v${ROOT_VERSION}.source.tar.gz && \
-    tar xvfz root_v${ROOT_VERSION}.source.tar.gz && \
-    mkdir build && \
-    cd build && \
-    cmake \
-      -Dall=OFF \
-      -Dcxx14=ON \
-      -Dfortran=FF \
-      -Droofit=ON \
-      -Droostats=ON \
-      -Dhistfactory=ON \
-      -Dminuit2=ON \
-      -Dpython=ON \
-      -DPYTHON_EXECUTABLE=$(which python3) \
-      -DCMAKE_INSTALL_PREFIX=/usr/local \
-      ../root-${ROOT_VERSION} && \
-    cmake --build . -- -j$(($(nproc) - 1)) && \
-    cmake --build . --target install
-
-FROM base
-RUN apt-get -qq -y update && \
-    apt-get -qq -y install \
-      gcc \
-      g++ \
-      zlibc \
-      libblas3 \
-      zlib1g-dev \
-      libbz2-dev \
-      libx11-dev \
-      libxext-dev \
-      libxft-dev \
-      libxml2-dev \
-      libxpm-dev \
-      libz-dev \
-      curl && \
-    apt-get -y autoclean && \
-    apt-get -y autoremove && \
-    rm -rf /var/lib/apt-get/lists/*
-# Use C.UTF-8 locale to avoid issues with ASCII encoding
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
-ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-COPY --from=builder /usr/local/bin /usr/local/bin
-COPY --from=builder /usr/local/lib /usr/local/lib
-COPY --from=builder /usr/local/include /usr/local/include
-COPY --from=builder /usr/local/share /usr/local/share
-COPY --from=builder /usr/local/etc /usr/local/etc
-COPY --from=builder /usr/local/fonts /usr/local/fonts
 
 WORKDIR /home/data
 ENV HOME /home

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ all: image
 image:
 	docker build . \
 	-f Dockerfile \
-	--build-arg BASE_IMAGE=python:3.7-slim \
-	--build-arg ROOT_VERSION=6.20.00 \
+	--build-arg BASE_IMAGE=atlasamglab/stats-base:root6.20.00-python3.7 \
 	--tag pyhf/pyhf-validation-root-base:root6.20.00 \
 	--tag pyhf/pyhf-validation-root-base:root6.20.00-python3.7 \
 	--tag pyhf/pyhf-validation-root-base:latest


### PR DESCRIPTION
Leverage that ATLAS already publishes on Docker Hub builds of ROOT meant for stats workflows that are built on top of the `python:3-slim` Docker images. Use the [`atlasamglab/stats-base:root6.20.00-python3.7` image](https://gitlab.cern.ch/atlas-amglab/atlstats) as the base image to save lots of build time.

```
* Use atlasamglab/stats-base:root6.20.00-python3.7 as base image
   - Allows for most of Dockerfile to be removed
   - Reduces build time to under 1 minute
* Add git to image for pyhf-validation tests
* Update ENTRYPOINT and CMD to be more user friendly for interactive sessions 
```