### PR TITLE
fix: Add curl to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ ARG BASE_IMAGE=atlasamglab/stats-base:root6.20.00-python3.7
 FROM ${BASE_IMAGE} as base
 
 RUN apt-get -qq -y update && \
-    apt-get -qq -y install --no-install-recommends git && \
+    apt-get -qq -y install --no-install-recommends \
+      curl \
+      git && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*


### PR DESCRIPTION
Fix PR #9 by adding `curl` back into the image that was dropped in error.

```
* Add curl to image
   - Amends PR #9
```