### PR TITLE
refactor: Update to smaller root6.20.04 base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       run: |
         docker build . \
           --file Dockerfile \
-          --build-arg BASE_IMAGE=atlasamglab/stats-base:root6.20.00-python3.7 \
+          --build-arg BASE_IMAGE=atlasamglab/stats-base:root6.20.04-python3.7 \
           --tag pyhf/pyhf-validation-root-base:$GITHUB_SHA \
           --compress
         docker images

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,4 +21,4 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         buildoptions: "--compress"
-        tags: "latest,root6.20.00,root6.20.00-python3.7"
+        tags: "latest,root6.20.04,root6.20.04-python3.7"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=atlasamglab/stats-base:root6.20.00-python3.7
+ARG BASE_IMAGE=atlasamglab/stats-base:root6.20.04-python3.7
 FROM ${BASE_IMAGE} as base
 
 RUN apt-get -qq -y update && \

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ all: image
 image:
 	docker build . \
 	-f Dockerfile \
-	--build-arg BASE_IMAGE=atlasamglab/stats-base:root6.20.00-python3.7 \
-	--tag pyhf/pyhf-validation-root-base:root6.20.00 \
-	--tag pyhf/pyhf-validation-root-base:root6.20.00-python3.7 \
+	--build-arg BASE_IMAGE=atlasamglab/stats-base:root6.20.04-python3.7 \
+	--tag pyhf/pyhf-validation-root-base:root6.20.04 \
+	--tag pyhf/pyhf-validation-root-base:root6.20.04-python3.7 \
 	--tag pyhf/pyhf-validation-root-base:latest
 
 run:


### PR DESCRIPTION
Given the changes in how the [ATLAS Stats base images are built](https://gitlab.cern.ch/atlas-amglab/atlstats/-/merge_requests/18) the `root6.20.04` based tags of them are much smaller and should be used.

```
* Update base image to atlasamglab/stats-base:root6.20.04-python3.7
   - Changes in the way the base image is built makes it significantly smaller
   - c.f. https://gitlab.cern.ch/atlas-amglab/atlstats/-/merge_requests/18
* Update tags in CI to indicate root6.20.04 is being used
```