### PR TITLE
ci: Use official Docker GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Build Docker image
-      run: |
-        docker build . \
-          --file Dockerfile \
-          --build-arg BASE_IMAGE=atlasamglab/stats-base:root6.20.04-python3.7 \
-          --tag pyhf/pyhf-validation-root-base:$GITHUB_SHA \
-          --compress
-        docker images
+      uses: docker/build-push-action@v1
+      with:
+        repository: pyhf/pyhf-validation-root-base
+        dockerfile: Dockerfile
+        tags: test
+        tag_with_sha: true
+        tag_with_ref: true
+        push: false
+    - name: List built images
+      run: docker images
     - name: Check PATH
       run: |
-        docker run --rm pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "which python;python --version;which root;root-config --version;hist2workspace --help"
-        docker run --rm pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "which curl;which tar"
+        docker run --rm pyhf/pyhf-validation-root-base:test "which python;python --version;which root;root-config --version;hist2workspace --help"
+        docker run --rm pyhf/pyhf-validation-root-base:test "which curl;which tar"
     - name: Run tests
       run: |
-        docker run --rm -v $PWD:$PWD -w $PWD pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "python tests/rf308_normintegration2d.py"
-        docker run --rm -v $PWD:$PWD -w $PWD pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "python -m pip install numpy; python tests/test_import_numpy_ROOT.py"
-        docker run --rm -v $PWD:$PWD -w $PWD pyhf/pyhf-validation-root-base:$GITHUB_SHA -c "python -m pip install numpy; python tests/test_import_ROOT_numpy.py"
+        docker run --rm -v $PWD:$PWD -w $PWD pyhf/pyhf-validation-root-base:test "python tests/rf308_normintegration2d.py"
+        docker run --rm -v $PWD:$PWD -w $PWD pyhf/pyhf-validation-root-base:test "python -m pip install numpy; python tests/test_import_numpy_ROOT.py"
+        docker run --rm -v $PWD:$PWD -w $PWD pyhf/pyhf-validation-root-base:test "python -m pip install numpy; python tests/test_import_ROOT_numpy.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build Docker image
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v1.1.0
       with:
         repository: pyhf/pyhf-validation-root-base
         dockerfile: Dockerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Build and Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.12
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
       with:
-        name: pyhf/pyhf-validation-root-base
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        buildoptions: "--compress"
-        tags: "latest,root6.20.04,root6.20.04-python3.7"
+        repository: pyhf/pyhf-validation-root-base
+        dockerfile: Dockerfile
+        tags: latest,root6.20.04,root6.20.04-python3.7
+    - name: Build and Publish to Registry with Release Tag
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: pyhf/pyhf-validation-root-base
+        dockerfile: Dockerfile
+        tags: latest,latest-stable,root6.20.04,root6.20.04-python3.7
+        tag_with_ref: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build and Publish to Registry
       if: "!(startsWith(github.ref, 'refs/tags/'))"
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v1.1.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -25,7 +25,7 @@ jobs:
         tags: latest,root6.20.04,root6.20.04-python3.7
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v1.1.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Use the [official Docker GitHub Action](https://github.com/docker/build-push-action) to publish to the Docker image to Docker Hub.

Using the `tag_with_ref` option, tag the image with the version release number and `latest-stable` when the push is a tag release.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use official Docker GitHub Action to publish to Docker Hub
   - Tag image with version release and 'latest-stable' tags if the push is a tag release
```